### PR TITLE
Update modulus calculation on plot_line_styles

### DIFF
--- a/deeptools/plotFingerprint.py
+++ b/deeptools/plotFingerprint.py
@@ -417,7 +417,7 @@ def main(args=None):
                 trace['line'].update(dash=plotly_line_styles[i % 36], color=plotly_colors[i % 6])
                 data.append(trace)
             else:
-                j = i % length(pyplot_line_styles)
+                j = i % len(pyplot_line_styles)
                 plt.plot(x, count, label=args.labels[i], linestyle=pyplot_line_styles[j])
                 plt.xlabel('rank')
                 plt.ylabel('fraction w.r.t. bin with highest coverage')

--- a/deeptools/plotFingerprint.py
+++ b/deeptools/plotFingerprint.py
@@ -417,7 +417,7 @@ def main(args=None):
                 trace['line'].update(dash=plotly_line_styles[i % 36], color=plotly_colors[i % 6])
                 data.append(trace)
             else:
-                j = i % 35
+                j = i % length(pyplot_line_styles)
                 plt.plot(x, count, label=args.labels[i], linestyle=pyplot_line_styles[j])
                 plt.xlabel('rank')
                 plt.ylabel('fraction w.r.t. bin with highest coverage')


### PR DESCRIPTION
pyplot_line_styles has a length of 28, the modulus calculation was taking mod 35. This leads to issues when a file list was longer than 28 files. Now it calculates the mod on the length of pyplot_line_styles.


**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature?
 - [x] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?
